### PR TITLE
Reduce the resource request

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -24,8 +24,8 @@ spec:
             cpu: 4
             memory: "4Gi"
           requests:
-            cpu: 2
-            memory: "4Gi"
+            cpu: 100m
+            memory: "128Mi"
         ports:
         - containerPort: 22
         command: ["/bin/sh", '-c']


### PR DESCRIPTION
This deployments is doing nothing but blocking 4Gb of memory fo every single instance. Reducing the resource request to something more appropiate